### PR TITLE
fix: 一部のmoocsのコースにて、ダウンロード時にpanicが発生する問題を修正

### DIFF
--- a/collect-core/src/moocs.rs
+++ b/collect-core/src/moocs.rs
@@ -244,7 +244,11 @@ impl LecturePage {
         let pagination = document
             .select(&scraper::Selector::parse("ul.pagination li").unwrap())
             .collect::<Vec<_>>();
-        let pagination = &pagination[1..pagination.len() - 1];
+        let pagination = if pagination.len() > 2 {
+            &pagination[1..pagination.len() - 1]
+        } else {
+            return vec![];
+        };
         let pages = pagination
             .iter()
             .map(|li| -> anyhow::Result<(String, Option<Url>)> {


### PR DESCRIPTION
## 今回修正したバグについて
2024年度コンピュータ・サイエンス演習IV / 情報連携基礎演習IVのダウンロード中に次のエラーが発生しました。
https://moocs.iniad.org/courses/2024/COT204

```bash
> RUST_BACKTRACE=full collect-cli 
ユーザー名: xxxxxxxxxx
パスワード: [hidden]
科目を選択: コンピュータ・サイエンス演習IV / 情報連携基礎演習IV
授業を選択: スケジュール - 00: スケジュール
⠙ ページを取得中...                                                                                                             thread 'main' panicked at collect-core/src/moocs.rs:247:37:
range end index 18446744073709551615 out of range for slice of length 0
stack backtrace:
   0:     0x62730b755b25 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h1b9dad2a88e955ff
   1:     0x62730b77db1b - core::fmt::write::h4b5a1270214bc4a7
   2:     0x62730b7523af - std::io::Write::write_fmt::hd04af345a50c312d
   3:     0x62730b756e21 - std::panicking::default_hook::{{closure}}::h96ab15e9936be7ed
   4:     0x62730b756afc - std::panicking::default_hook::h3cacb9c27561ad33
   5:     0x62730b757481 - std::panicking::rust_panic_with_hook::hfe205f6954b2c97b
   6:     0x62730b7572e7 - std::panicking::begin_panic_handler::{{closure}}::h6cb44b3a50f28c44
   7:     0x62730b755fe9 - std::sys::backtrace::__rust_end_short_backtrace::hf1c1f2a92799bb0e
   8:     0x62730b756f74 - rust_begin_unwind
   9:     0x62730b038e43 - core::panicking::panic_fmt::h3d8fc78294164da7
  10:     0x62730b0393f7 - core::slice::index::slice_end_index_len_fail::h87b545b7962eada9
  11:     0x62730b108e96 - collect_core::moocs::LecturePage::scrape_page::h69d580312cc2119b
  12:     0x62730b03b8fe - collect_core::moocs::Lecture::pages::{{closure}}::h63ab07e4e7c6b974
  13:     0x62730b046ad8 - collect_cli::main::{{closure}}::h3256c7106874db77
  14:     0x62730b044ca8 - tokio::runtime::park::CachedParkThread::block_on::h24d55afe356900bc
  15:     0x62730b0cccad - tokio::runtime::runtime::Runtime::block_on::hd91376a6b78a9232
  16:     0x62730b0e6549 - collect_cli::main::h748ed3e3c4ab89ed
  17:     0x62730b0b7533 - std::sys::backtrace::__rust_begin_short_backtrace::hc916d27ec03ee762
  18:     0x62730b0cd9bd - std::rt::lang_start::{{closure}}::h62a18f9416375beb
  19:     0x62730b749900 - std::rt::lang_start_internal::h5e7c81cecd7f0954
  20:     0x62730b0e6625 - main
  21:     0x7e9f65c2a1ca - <unknown>
  22:     0x7e9f65c2a28b - __libc_start_main
  23:     0x62730b039755 - _start
  24:                0x0 - <unknown>
```

ダウンロードしようとしたページを調べてみると、正常にダウンロードできるページと比べ、以下の相違点があることがわかりました。
ダウンロード対象のページ: https://moocs.iniad.org/courses/2024/COT204/00

- Table of Contentsにページのリンクが存在するのにもかかわらずアクセスするとhttp status code 302によって、メインページにリダイレクトされる
- このページのスクレイピングの際に`collect-core/src/moocs.rs`244行目のpaginationのvectorの長さが0になる

これにより、`collect-core/src/moocs.rs`247行目のスライス処理でout of rangeが発生したものだと思われます。
そこで次の変更を加えました。


## 変更点

* [`collect-core/src/moocs.rs`](diffhunk://#diff-4beb1947b15571da6d48f03c955fb42b733ca03c69621f6712929e206ab13ec8L247-R251): コンピュータ・サイエンス演習IV / 情報連携基礎演習IV/スケジュール - 00: スケジュールでPaginationのvectorの長さが0になってしまっていて、スライス時にpanicを引き起こしていたので、vectorが短すぎる場合はスライスを行わないように変更しました。


お忙しいと思いますが、レビューのほどをよろしくお願いいたします。