### PR TITLE
埋め込みのURL形式が違う講義スライドも取得する

### DIFF
--- a/collect-core/src/moocs.rs
+++ b/collect-core/src/moocs.rs
@@ -345,7 +345,7 @@ impl Slide {
     pub fn scrape_page(html: &str) -> Vec<String> {
         let document = Html::parse_document(html);
         let gslide_regex =
-            Regex::new(r#"^https://docs.google.com/presentation/d/.*?/embed\?"#).unwrap();
+            Regex::new(r#"^https://docs.google.com/presentation/d/.*?/(embed|pubembed)\?"#).unwrap();
         let slides = document
             .select(&scraper::Selector::parse("iframe").unwrap())
             .filter_map(|iframe| iframe.value().attr("src"))


### PR DESCRIPTION
[コンピュータ・システム論C lec4](https://moocs.iniad.org/courses/2025/COS207/lec04/02) などのいくつかの講義でスライドのダウンロードが取得できないバグを修正しました。

Google Slidesの公開設定?によってはurlが `https://docs.google.com/presentation/d/***/embed` ではなく `https://docs.google.com/presentation/d/***/pubembed`になるため、どちらのURLでもマッチするように修正しています。

cli, app 両方で以前ダウンロードできなかった[コンピュータ・システム論C lec4](https://moocs.iniad.org/courses/2025/COS207/lec04/02)が正しくダウンロードできることを確認しています。